### PR TITLE
Exclude single partner pages from rendering and search

### DIFF
--- a/content/foundationalActivities/_index.md
+++ b/content/foundationalActivities/_index.md
@@ -4,5 +4,12 @@ description = "The ARCTIC program was modeled on the Asia-Pacific Technology and
 FAdiagram = "images/fa-diagram.png"
 heroBackgroundImage = "images/backgroundImages/2022_ARENA_GROUP_KOtz-108.jpg"
 type = "foundationalActivities"
+[build]
+  render = 'always'
+[[cascade]]
+  [cascade.build]
+    list = 'local'
+    publishResources = false
+    render = 'never'
 +++
 ARCTIC’s five foundational activities are deeply integrated with partners at the local and state levels. Guided by a cross-cutting Program Management and Support task, these activities exemplify the collaborative efforts driving Alaska’s resilience and innovation economy. The figure above illustrates how these foundational activities are achieved through partnerships across a dynamic ecosystem.

--- a/content/partners/_index.md
+++ b/content/partners/_index.md
@@ -2,4 +2,11 @@
 title = "Core Partners"
 description = "Since its establishment, the ARCTIC program has grown significantly, now partnering with over 200 organizations across sectors such as academia, industry, government, and nonprofits. Its core leadership includes five key organizations: three within the University of Alaska system—ACEP, Center ICE, and CED—and two external partners, REAP and Launch Alaska."
 heroBackgroundImage = "images/backgroundImages/2024-April-ONR-Visit-76.jpg"
+[build]
+  render = 'always'
+[[cascade]]
+  [cascade.build]
+    list = 'local'
+    publishResources = false
+    render = 'never'
 +++


### PR DESCRIPTION
This excludes single partner and foundational Activities pages from rendering (excludes pages from site maps and search results)