### PR TITLE
Clean up styles/elements

### DIFF
--- a/assets/js/lightbox.js
+++ b/assets/js/lightbox.js
@@ -35,13 +35,6 @@ const aboutLightbox = new PhotoSwipeLightbox({
   pswpModule: PhotoSwipe,
 });
 
-const activitiesLightbox = new PhotoSwipeLightbox({
-  gallery: '#gallery__activities',
-  children: '.pswp-gallery__item',
-  pswpModule: PhotoSwipe,
-});
-
 // Initialize Lightboxes
 homeLightbox.init();
 aboutLightbox.init();
-activitiesLightbox.init();

--- a/assets/scss/_footer.scss
+++ b/assets/scss/_footer.scss
@@ -1,0 +1,35 @@
+.footer-logo {
+  max-width: 300px;
+}
+
+.footer-list {
+  padding-left: 0;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  column-gap: 2rem;
+
+  li {
+    list-style: none;
+  }
+}
+
+.footer-flexbox {
+  display: flex;
+  justify-content: center;
+  gap: 4rem;
+  flex-wrap: wrap;
+  width: 100%;
+
+  .partner-item-sm {
+    max-width: 200px;
+    max-height: 100px;
+    text-align: center;
+    transition: 0.3s ease;
+    align-self: center;
+
+    &:hover {
+      animation: hover 0.3s ease;
+      transform: scale3d(1.05, 1.05, 1.05);
+    }
+  }
+}

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -41,18 +41,22 @@ h1 {
   padding: 1rem;
 }
 
+@media (min-width: 992px) {
+  .grid-post {
+    grid-template-columns: repeat(2, 1fr) !important;
+  }
+}
+
 .grid {
   margin-bottom: 3rem !important;
-  justify-items: center;
 
   &.home {
     gap: 2rem;
   }
 
   &.about {
-    gap: 2rem;
+    gap: 2em;
   }
-
 }
 
 .grid-wrapper.about {
@@ -64,12 +68,10 @@ h1 {
   flex-direction: column;
   align-items: center;
   text-align: center;
-  height: 100%;  
+  height: 100%;
 }
 
 .grid-card.home {
-  display: flex;
-  flex-direction: column;
   align-items: start;
   gap: 1rem;
   width: 100%;
@@ -89,11 +91,8 @@ h1 {
 }
 
 .grid-card.about {
-  display: flex;
-  flex-direction: column;
   align-items: start;
   gap: 2rem;
-  width: 100%;
   background-color: var(--small-card-background-color);
   color: var(--small-card-text-color) !important;
 
@@ -122,7 +121,7 @@ h1 {
 
     img {
       width: 250px;
-      height: 150px; 
+      height: 150px;
       object-fit: contain; /* Ensures the entire image fits within the box */
       max-width: 100%;
       max-height: 100%;
@@ -194,6 +193,31 @@ h1 {
       list-style: disc;
     }
   }
+
+  .fa-footer {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 1rem;
+    width: 100%;
+    background-color: var(--partner-card-header-color);
+    padding: 1rem;
+    justify-content: flex-end;
+    align-items: center;
+    color: var(--hgroup-text-color);
+    min-height: 100px;
+
+    img.partner-logo-sm {
+      max-width: 150px;
+      max-height: 50px;
+      object-fit: contain;
+
+      &:hover {
+        animation: hover 0.3s ease;
+        transform: scale3d(1.05, 1.05, 1.05);
+      }
+    }
+  }
 }
 
 #gallery__home {
@@ -207,44 +231,5 @@ h1 {
     max-width: 100%; /* Ensure the image doesn't overflow */
     height: auto; /* Maintain aspect ratio */
     object-fit: contain; /* Ensure the image fits nicely within the container */
-  }
-}
-
-/* Medium devices (tablets, 768px and up) */
-@media (min-width: 992px) {
-  .grid-post {
-    grid-template-columns: repeat(2, 1fr) !important;
-  }
-}
-
-/* Large devices (desktops, 1200px and up) */
-@media (min-width: 1200px) {
-  :root {
-    --font-size: 1.125rem;
-  }
-}
-
-.partner-flexbox {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  gap: 1rem;
-  width: 100%;
-  background-color: var(--partner-card-header-color);
-  padding: 1rem;
-  justify-content: flex-end;
-  align-items: center;
-  color: var(--hgroup-text-color);
-  min-height: 100px;
-
-  img.partner-logo-sm {
-    max-width: 150px;
-    max-height: 50px;
-    object-fit: contain;
-
-    &:hover {
-      animation: hover 0.3s ease;
-      transform: scale3d(1.05, 1.05, 1.05);
-    }
   }
 }

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -2,6 +2,7 @@
 @import 'nav';
 @import 'variables';
 @import 'about';
+@import 'footer';
 
 h1 {
   font-size: 1.9rem !important; /* Force ARCTIC title on one line */
@@ -19,32 +20,51 @@ h1 {
   font-size: 0.8rem !important;
 }
 
-.h2-link {
-  text-decoration: none;
-  transition: color 0.3s ease, background-color 0.3s ease;
+.no-hover-effect {
+  transition: none !important;
+  animation: none !important;
+  transform: none !important;
+}
 
-  &:hover {
-    color: var(--link-color);
-  }
+.underlay {
+  background-color: rgba(0, 0, 0, 0.45);
+  padding: 1rem;
+  border-radius: 8px;
+  margin-top: 1rem;
+  color: white;
+}
+
+.image-credit {
+  font-size: 0.8rem;
+  color: var(--muted-color);
+  text-align: end;
+  padding: 1rem;
 }
 
 .grid {
   margin-bottom: 3rem !important;
   justify-items: center;
-}
 
-.grid.home,
-.grid.about {
-  gap: 2rem;
+  &.home {
+    gap: 2rem;
+  }
+
+  &.about {
+    gap: 2rem;
+  }
+
 }
 
 .grid-wrapper.about {
   margin-bottom: 5rem;
 }
 
-.grid-card.partner,
-.grid-card.fa {
-  padding: 0 !important;
+.grid-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  height: 100%;  
 }
 
 .grid-card.home {
@@ -85,13 +105,8 @@ h1 {
   }
 }
 
-.grid-card {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  height: 100%;
-
+.grid-card.partner {
+  padding: 0 !important;
   .partner-hgroup {
     width: 100%;
     background-color: var(--partner-card-header-color);
@@ -106,8 +121,8 @@ h1 {
     margin-bottom: 0;
 
     img {
-      width: 250px; /* Define a fixed width */
-      height: 150px; /* Define a fixed height */
+      width: 250px;
+      height: 150px; 
       object-fit: contain; /* Ensures the entire image fits within the box */
       max-width: 100%;
       max-height: 100%;
@@ -119,6 +134,27 @@ h1 {
     }
   }
 
+  .partner-content {
+    padding: calc(var(--spacing) * 1.2) var(--block-spacing-horizontal);
+    p {
+      color: var(--card-body-text-color) !important;
+      text-decoration: none;
+    }
+    li {
+      color: var(--card-body-text-color) !important;
+      list-style: none;
+      text-align: start;
+    }
+  }
+
+  .partner-footer {
+    margin-bottom: 1.5rem;
+    margin-top: auto;
+  }
+}
+
+.grid-card.fa {
+  padding: 0 !important;
   .fa-hgroup {
     width: 100%;
     background-color: var(--card-header-color);
@@ -139,28 +175,6 @@ h1 {
     }
   }
 
-  .partner-content,
-  .fa-content {
-    padding: calc(var(--spacing) * 1.2) var(--block-spacing-horizontal);
-  }
-
-  .partner-content {
-    p {
-      color: var(--card-body-text-color) !important;
-      text-decoration: none;
-    }
-    li {
-      color: var(--card-body-text-color) !important;
-      list-style: none;
-      text-align: start;
-    }
-  }
-
-  .partner-footer {
-    margin-bottom: 1.5rem;
-    margin-top: auto; /* Distance from the right edge of the card */
-  }
-
   .fa-content {
     display: flex;
     flex-direction: column;
@@ -169,6 +183,7 @@ h1 {
     text-align: start;
     justify-content: space-between;
     height: 100%;
+    padding: calc(var(--spacing) * 1.2) var(--block-spacing-horizontal);
 
     p,
     li {
@@ -181,25 +196,18 @@ h1 {
   }
 }
 
-#gallery__activities {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-direction: column;
-}
-
 #gallery__home {
   display: flex; /* Use flexbox for alignment */
   justify-content: center; /* Center horizontally */
   align-items: center; /* Center vertically */
   height: 100%; /* Ensure the container takes up the full height */
   text-align: center; /* Ensure inline elements like text are also centered */
-}
 
-#gallery__home img {
-  max-width: 100%; /* Ensure the image doesn't overflow */
-  height: auto; /* Maintain aspect ratio */
-  object-fit: contain; /* Ensure the image fits nicely within the container */
+  img {
+    max-width: 100%; /* Ensure the image doesn't overflow */
+    height: auto; /* Maintain aspect ratio */
+    object-fit: contain; /* Ensure the image fits nicely within the container */
+  }
 }
 
 /* Medium devices (tablets, 768px and up) */
@@ -216,36 +224,6 @@ h1 {
   }
 }
 
-// Override to remove hover effect
-.no-hover-effect {
-  transition: none !important;
-  animation: none !important;
-  transform: none !important;
-}
-
-.footer-logo {
-  max-width: 300px;
-}
-
-.footer-list {
-  padding-left: 0;
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  column-gap: 2rem;
-
-  li {
-    list-style: none;
-  }
-}
-
-.flexbox-container {
-  display: flex;
-  justify-content: center;
-  gap: 4rem;
-  flex-wrap: wrap;
-  width: 100%;
-}
-/* Additional customization for partner-specific flexbox */
 .partner-flexbox {
   display: flex;
   flex-direction: row;
@@ -259,37 +237,14 @@ h1 {
   color: var(--hgroup-text-color);
   min-height: 100px;
 
-  .fa-partner-logo {
-    max-width: 125px;
+  img.partner-logo-sm {
+    max-width: 150px;
     max-height: 50px;
     object-fit: contain;
+
+    &:hover {
+      animation: hover 0.3s ease;
+      transform: scale3d(1.05, 1.05, 1.05);
+    }
   }
-}
-
-.partner-item-sm {
-  max-width: 200px;
-  max-height: 100px;
-  text-align: center;
-  transition: 0.3s ease;
-  align-self: center;
-
-  &:hover {
-    animation: hover 0.3s ease;
-    transform: scale3d(1.05, 1.05, 1.05);
-  }
-}
-
-.underlay {
-  background-color: rgba(0, 0, 0, 0.45);
-  padding: 1rem;
-  border-radius: 8px;
-  margin-top: 1rem;
-  color: white;
-}
-
-.image-credit {
-  font-size: 0.8rem;
-  color: var(--muted-color);
-  text-align: end;
-  padding: 1rem;
 }

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -92,12 +92,15 @@ h1 {
 
 .grid-card.about {
   align-items: start;
-  gap: 2rem;
   background-color: var(--small-card-background-color);
   color: var(--small-card-text-color) !important;
+  
+  .feather-icon {
+    margin-bottom: 1rem !important;
+    margin-top: 1rem !important;
+  }
 
   .title {
-    margin-bottom: 0;
     text-align: start;
     font-weight: 500;
     color: var(--small-card-text-color) !important;

--- a/layouts/about/single.html
+++ b/layouts/about/single.html
@@ -25,7 +25,7 @@
     <div class="grid about">
       {{ range .Params.cards_section.cards }}
         <article class="grid-card about">
-          <i data-feather="{{ .icon }}"></i>
+          <i class="feather-icon" data-feather="{{ .icon }}"></i>
           <p class="title">{{ .title }}</p>
         </article>
       {{ end }}

--- a/layouts/foundationalActivities/list.html
+++ b/layouts/foundationalActivities/list.html
@@ -34,26 +34,20 @@
           </span>
         </div>
         {{ $partners := .Params.partners }}
-        <div class="flexbox-container">
           <div class="partner-flexbox">
             <i>Led by:</i>
             {{ with .Site.GetPage "section" "partners" }}
-            {{ range .Pages }}
-              {{ if in $partners .Params.id }}
-                <span class="partner-item-sm">
+              {{ range .Pages }}
+                {{ if in $partners .Params.id }}
                   <a href="{{ .Params.websiteURL }}" target="_blank" rel="noopener noreferrer">
                     {{ with .Resources.GetMatch "*logo.*" }}
-                      <img src="{{ .RelPermalink }}" alt="{{ .Title }}" class="fa-partner-logo" />
-                    {{ else }}
-                      <p>No logo found for {{ .Title }}</p>
+                      <img class="partner-logo-sm" src="{{ .RelPermalink }}" alt="{{ .Title }}" />
                     {{ end }}
                   </a>
-                </span>
+                {{ end }}
               {{ end }}
             {{ end }}
-            {{ end }}
           </div>
-        </div>
       </article>
     {{ end }}
   </div>

--- a/layouts/foundationalActivities/list.html
+++ b/layouts/foundationalActivities/list.html
@@ -34,7 +34,7 @@
           </span>
         </div>
         {{ $partners := .Params.partners }}
-          <div class="partner-flexbox">
+          <div class="fa-footer">
             <i>Led by:</i>
             {{ with .Site.GetPage "section" "partners" }}
               {{ range .Pages }}

--- a/layouts/partials/footer_logos.html
+++ b/layouts/partials/footer_logos.html
@@ -1,17 +1,21 @@
-<div class="flexbox-container">
-  {{ with .Site.GetPage "section" "partners" }}
-    {{ range .Pages }}
-      {{ if eq .Params.showInFooter true }}
-        <div class="partner-item-sm">
-          <a href="{{ .Params.websiteUrl }}" target="_blank" title="{{ .Title }}">
-            {{ with .Resources.GetMatch "*logo.*" }}
-              <img src="{{ .RelPermalink }}" alt="{{ .Params.alt }}">
-            {{ else }}
-              <p>No logo available for {{ .Title }}</p>
-            {{ end }}
-          </a>
-        </div>
+<div class="footer-flexbox">
+  {{ with .Site.GetPage "section" "partners" }} {{ range .Pages }} {{ if eq
+  .Params.showInFooter true }}
+  <div class="partner-item-sm">
+    <a
+      href="{{ .Params.websiteUrl }}"
+      target="_blank"
+      title="{{ .Title }}"
+    >
+      {{ with .Resources.GetMatch "*logo.*" }}
+      <img
+        src="{{ .RelPermalink }}"
+        alt="{{ .Params.alt }}"
+      />
+      {{ else }}
+      <p>No logo available for {{ .Title }}</p>
       {{ end }}
-    {{ end }}
-  {{ end }}
+    </a>
+  </div>
+  {{ end }} {{ end }} {{ end }}
 </div>

--- a/layouts/partners/list.html
+++ b/layouts/partners/list.html
@@ -32,7 +32,7 @@
         <hgroup class="partner-hgroup">
           <!-- Display the logo from leaf bundle -->
           {{ with .Resources.GetMatch "*logo.*" }}
-            <img class="partner-logos" src="{{ .RelPermalink }}" alt="Logo for {{ $.Params.name }}">
+            <img src="{{ .RelPermalink }}" alt="Logo for {{ $.Params.name }}">
           {{ end }}
           <h5 hidden>{{ .Title }}</h5>
           <i class="tagline">{{- .Params.Tagline -}}</i>


### PR DESCRIPTION
This PR cleans up stylesheets by:
- Removing unused styles/classes
- Refactors styles to avoid redundancy
- Removes redundant elements
- Renames classes to give better semantic meaning 
- Add `_footer.scss` for footer styles